### PR TITLE
Add cors to dummy api for JS tracker local dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ end
 
 group :dummy do
   gem 'sinatra', '~> 2.2'
+  gem 'sinatra-cors', '~> 1.2'
   gem 'puma', '~> 5.5'
   gem 'rouge', '~> 3.30'
 end

--- a/dummy-api/app.rb
+++ b/dummy-api/app.rb
@@ -1,9 +1,14 @@
 require "bundler/setup"
 require "sinatra"
+require "sinatra/cors"
 require "rouge"
 
 shell_formatter = Rouge::Formatters::Terminal256.new
 lexer = Rouge::Lexers::JSON.new
+
+set :allow_origin, "*"
+set :allow_methods, "POST,OPTIONS"
+set :allow_headers, "Authorization, Content-Type"
 
 post "/events" do
   data   = JSON.load(request.body.read)


### PR DESCRIPTION
Modified the dummy api slightly so the JS tracker can call it in local development without CORS issues.

Related to https://github.com/valued-app/valued.js/pull/5


<img width="1484" alt="Screen Shot 2022-10-03 at 5 57 10 PM" src="https://user-images.githubusercontent.com/8061663/193700332-56c9d889-73ac-48bb-84ca-c89843e269d0.png">
