### PR TITLE
Add config event support

### DIFF
--- a/valued-client/lib/valued.rb
+++ b/valued-client/lib/valued.rb
@@ -10,6 +10,7 @@ require "time"
 module Valued
   require "valued/helpers"
   require "valued/client"
+  require "valued/config"
   require "valued/data"
   require "valued/connection"
   require "valued/scope"

--- a/valued-client/lib/valued.rb
+++ b/valued-client/lib/valued.rb
@@ -110,6 +110,39 @@ module Valued
     block ? @scope.scope(data, &block) : @scope.apply(data)
   end
 
+  # @example Called with a data hash
+  #   Valued.config({
+  #     goals : [
+  #       {
+  #         name: "This is the name of the goal",
+  #         action_key: "Portal.Expense.Created",
+  #         min_count: 5
+  #       }
+  #     ],
+  #     signals: [
+  #       {
+  #         name: "This is the name of the goal",
+  #         action_key: "Portal.Expense.Created",
+  #         min_count: 5
+  #       }
+  #     ]
+  #   })
+  #
+  # @example Called with a block
+  #   Valued.config do |config|
+  #     # Create or update a goal
+  #     config.add_goal("This is the name of the goal",
+  #       action_key: "Portal.Expense.Created",
+  #       min_count: 5)
+  #
+  #     # Create or update a signal
+  #     config.add_signal("This is the name of the signal",
+  #       action_key: "Portal.Expense.Created")
+  #   end
+  #
+  # @return [void]
+  def config(...) = client.config(...)
+
   # Resets the shared scope.
   # @see Valued::Scope#reset
   # @return [void]

--- a/valued-client/lib/valued.rb
+++ b/valued-client/lib/valued.rb
@@ -112,7 +112,7 @@ module Valued
 
   # @example Called with a data hash
   #   Valued.config({
-  #     goals : [
+  #     goals: [
   #       {
   #         name: "This is the name of the goal",
   #         action_key: "Portal.Expense.Created",

--- a/valued-client/lib/valued/client.rb
+++ b/valued-client/lib/valued/client.rb
@@ -71,7 +71,7 @@ class Valued::Client
 
   # @example Called with a data hash
   #   client.config({
-  #     goals : [
+  #     goals: [
   #       {
   #         name: "This is the name of the goal",
   #         action_key: "Portal.Expense.Created",

--- a/valued-client/lib/valued/client.rb
+++ b/valued-client/lib/valued/client.rb
@@ -69,6 +69,45 @@ class Valued::Client
   # @return [void]
   def sync_customer(data) = sync("customer" => data)
 
+  # @example Called with a data hash
+  #   client.config({
+  #     goals : [
+  #       {
+  #         name: "This is the name of the goal",
+  #         action_key: "Portal.Expense.Created",
+  #         min_count: 5
+  #       }
+  #     ],
+  #     signals: [
+  #       {
+  #         name: "This is the name of the goal",
+  #         action_key: "Portal.Expense.Created",
+  #         min_count: 5
+  #       }
+  #     ]
+  #   })
+  #
+  # @example Called with a block
+  #   client.config do |config|
+  #     # Create or update a goal
+  #     config.add_goal("This is the name of the goal",
+  #       action_key: "Portal.Expense.Created",
+  #       min_count: 5)
+  #
+  #     # Create or update a signal
+  #     config.add_signal("This is the name of the signal",
+  #       action_key: "Portal.Expense.Created")
+  #   end
+  #
+  # @return [void]
+  def config(data = nil)
+    if block_given?
+      data = Valued::Config.new(data)
+      yield data
+    end
+    send_event("config", data: data)
+  end
+
   private
 
   def send_event(category, data)

--- a/valued-client/lib/valued/config.rb
+++ b/valued-client/lib/valued/config.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Small configuration DSL to create goals and signals.
+class Valued::Config
+  # @see Client#config
+  # @api private
+  def initialize(data = nil)
+    @data = Data.normalize(data || {})
+    @data["signals"] ||= []
+    @data["goals"] ||= []
+  end
+
+  def add(type, info)
+  end
+
+  # @return [Hash] The configuration data as expected by the Valued API.
+  def to_h = @data
+  alias_method :to_valued_data, :to_h
+end


### PR DESCRIPTION
Adds a small API for [config events](https://github.com/valued-app/platform/pull/354).

Example with a block:

``` ruby
Valued.config do |config|
  # Create or update a goal
  config.add_goal("This is the name of the goal",
    action_key: "Portal.Expense.Created",
    min_count: 5)

  # Create or update a signal
  config.add_signal("This is the name of the signal",
    action_key: "Portal.Expense.Created")
end
```

Example with a data hash:

``` ruby
Valued.config({
  goals: [
    {
      name: "This is the name of the goal",
      action_key: "Portal.Expense.Created",
      min_count: 5
    }
  ],
  signals: [
    {
      name: "This is the name of the goal",
      action_key: "Portal.Expense.Created",
      min_count: 5
    }
  ]
})
```